### PR TITLE
Add likelihood and MCMC interfaces

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,46 +1,15 @@
-"""sl_inference package
+"""sl_inference_restart package.
 
-Tools for modelling strong gravitational lenses and performing inference on their physical properties. The
-module provides convenient imports for the most commonly used classes and functions."""
+Minimal package initialisation exposing the core inference utilities.
+"""
 
-from .lens_model import LensModel
-from .lens_solver import solve_single_lens, solve_lens_parameters_from_obs, compute_detJ
-from .lens_properties import lens_properties, observed_data
-from .mass_sampler import (
-    mstar_gene,
-    logRe_given_logM,
-    logMh_given_logM_logRe,
-    generate_samples,
-)
 from .run_mcmc import run_mcmc
-from .likelihood import (
-    set_context,
-    initializer_for_pool,
-    log_prior,
-    likelihood_single_fast_optimized,
-    log_likelihood,
-    log_posterior,
-)
+from .likelihood import log_prior, log_likelihood, log_posterior
 from .utils import selection_function, mag_likelihood
 
 __all__ = [
-    "LensModel",
-    "solve_single_lens",
-    "solve_lens_parameters_from_obs",
-    "compute_detJ",
-    "lens_properties",
-    "observed_data",
-    "mstar_gene",
-    "logRe_given_logM",
-    "logMh_given_logM_logRe",
-    "generate_samples",
-    "theoretical_logRe_pdf",
-    "theoretical_logMh_pdf",
     "run_mcmc",
-    "set_context",
-    "initializer_for_pool",
     "log_prior",
-    "likelihood_single_fast_optimized",
     "log_likelihood",
     "log_posterior",
     "selection_function",

--- a/likelihood.py
+++ b/likelihood.py
@@ -1,0 +1,184 @@
+"""Likelihood evaluation using pre-tabulated lensing grids.
+
+This module builds upon :func:`make_tabulate.tabulate_likelihood_grids`
+which pre-computes, for each observed lens, a grid of quantities required by
+our likelihood evaluation.  Given these grids and the observed stellar masses
+(from SPS modelling), the functions here compute the likelihood and posterior
+for the population hyper-parameters.
+
+The implementation is a streamlined version of the legacy code located in
+``old_script/likelihood.py`` and avoids re-solving the lens equation at every
+step of the MCMC.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, Sequence
+
+import numpy as np
+from scipy.stats import norm
+
+from .cached_A import cached_A_interp
+from .make_tabulate.make_tabulate import LensGrid, tabulate_likelihood_grids
+
+
+# -----------------------------------------------------------------------------
+# Utility API
+# -----------------------------------------------------------------------------
+
+def precompute_grids(
+    mock_observed_data,
+    logMh_grid: Iterable[float],
+    zl: float = 0.3,
+    zs: float = 2.0,
+    ms: float = 26.0,
+    sigma_m: float = 0.1,
+    m_lim: float = 26.5,
+) -> list[LensGrid]:
+    """Convenience wrapper around :func:`tabulate_likelihood_grids`.
+
+    Parameters are passed directly to :func:`tabulate_likelihood_grids`.
+    """
+
+    return tabulate_likelihood_grids(
+        mock_observed_data,
+        logMh_grid,
+        zl=zl,
+        zs=zs,
+        ms=ms,
+        sigma_m=sigma_m,
+        m_lim=m_lim,
+    )
+
+
+# -----------------------------------------------------------------------------
+# Likelihood and posterior
+# -----------------------------------------------------------------------------
+
+
+def log_prior(theta: Sequence[float]) -> float:
+    """Simple flat priors for the population hyper-parameters.
+
+    ``theta`` is expected to contain ``(mu0, beta, sigmaDM, mu_alpha, sigma_alpha)``.
+    """
+
+    mu0, beta, sigmaDM, mu_alpha, sigma_alpha = theta
+    if not (
+        12.0 < mu0 < 13.0
+        and 0.1 < sigmaDM < 0.5
+        and 0.0 < sigma_alpha < 0.4
+        and -0.1 < mu_alpha < 0.3
+        and 1.0 < beta < 3.0
+    ):
+        return -np.inf
+    return 0.0
+
+
+def _single_lens_likelihood(
+    grid: LensGrid,
+    logM_sps_obs: float,
+    theta: Sequence[float],
+    logalpha_grid: np.ndarray,
+) -> float:
+    """Evaluate the integral for one lens on the supplied grids."""
+
+    mu0, beta, sigmaDM, mu_alpha, sigma_alpha = theta
+
+    # Extract arrays and mask invalid entries
+    mask = (
+        np.isfinite(grid.logM_star)
+        & np.isfinite(grid.detJ)
+        & (grid.detJ > 0)
+        & np.isfinite(grid.p_magA)
+        & np.isfinite(grid.p_magB)
+    )
+    if not np.any(mask):
+        return 0.0
+
+    logMh = grid.logMh_grid[mask]
+    logM_star = grid.logM_star[mask]
+    detJ = grid.detJ[mask]
+    selA = grid.selA[mask]
+    selB = grid.selB[mask]
+    p_magA = grid.p_magA[mask]
+    p_magB = grid.p_magB[mask]
+
+    const = detJ * selA * selB * p_magA * p_magB
+
+    p_logMh = norm.pdf(
+        logMh, loc=mu0 + beta * (logM_star - 11.4), scale=sigmaDM
+    )
+    p_logalpha = norm.pdf(logalpha_grid, loc=mu_alpha, scale=sigma_alpha)
+
+    # Broadcasting shapes: (Nalpha, Nm) = (len(logalpha_grid), len(logMh))
+    p_Mstar = norm.pdf(
+        logM_sps_obs,
+        loc=logM_star[None, :] - logalpha_grid[:, None],
+        scale=0.1,
+    )
+
+    Z = p_Mstar * p_logalpha[:, None] * p_logMh[None, :] * const[None, :]
+
+    # Integrate over logalpha and logMh
+    integral_alpha = np.trapz(Z, logalpha_grid, axis=0)
+    integral = np.trapz(integral_alpha, logMh)
+
+    return float(max(integral, 1e-300))
+
+
+def log_likelihood(
+    theta: Sequence[float],
+    grids: Sequence[LensGrid],
+    logM_sps_obs: Sequence[float],
+    logalpha_grid: np.ndarray | None = None,
+) -> float:
+    """Compute the joint log-likelihood for all lenses."""
+
+    mu0, beta, sigmaDM, mu_alpha, sigma_alpha = theta
+    if sigmaDM <= 0 or sigma_alpha <= 0 or sigmaDM > 2.0 or sigma_alpha > 2.0:
+        return -np.inf
+
+    try:
+        A_eta = cached_A_interp(mu0, sigmaDM, beta, 0.0)
+        if not np.isfinite(A_eta) or A_eta <= 0:
+            return -np.inf
+    except Exception:
+        return -np.inf
+
+    if logalpha_grid is None:
+        logalpha_grid = np.linspace(mu_alpha - 4 * sigma_alpha, mu_alpha + 4 * sigma_alpha, 35)
+
+    logL = 0.0
+    for grid, logM_obs in zip(grids, logM_sps_obs):
+        L_i = _single_lens_likelihood(grid, float(logM_obs), theta, logalpha_grid)
+        if not np.isfinite(L_i) or L_i <= 0:
+            return -np.inf
+        logL += np.log(L_i / A_eta)
+
+    return float(logL)
+
+
+def log_posterior(
+    theta: Sequence[float],
+    grids: Sequence[LensGrid],
+    logM_sps_obs: Sequence[float],
+    logalpha_grid: np.ndarray | None = None,
+) -> float:
+    """Posterior = prior + likelihood."""
+
+    lp = log_prior(theta)
+    if not np.isfinite(lp):
+        return -np.inf
+    ll = log_likelihood(theta, grids, logM_sps_obs, logalpha_grid)
+    if not np.isfinite(ll):
+        return -np.inf
+    return lp + ll
+
+
+__all__ = [
+    "precompute_grids",
+    "log_prior",
+    "log_likelihood",
+    "log_posterior",
+]

--- a/run_mcmc.py
+++ b/run_mcmc.py
@@ -1,0 +1,68 @@
+"""Run MCMC sampling for the lens population parameters.
+
+This module provides a thin wrapper around :mod:`emcee` that ties together the
+mock-data generation, grid tabulation and likelihood evaluation.
+
+Usage is intentionally simple: supply the mock observed data and a grid in
+``logM_halo`` on which the lensing quantities were pre-computed.  The returned
+sampler object from :mod:`emcee` can then be further analysed.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import emcee
+from emcee.backends import HDFBackend
+
+from .likelihood import log_posterior
+
+
+def run_mcmc(
+    grids,
+    logM_sps_obs,
+    *,
+    nwalkers: int = 50,
+    nsteps: int = 3000,
+    initial_guess: np.ndarray | None = None,
+    backend_file: str = "chains_eta.h5",
+) -> emcee.EnsembleSampler:
+    """Sample the posterior using :mod:`emcee`.
+
+    Parameters
+    ----------
+    grids:
+        List of :class:`~make_tabulate.LensGrid` produced by
+        :func:`make_tabulate.tabulate_likelihood_grids`.
+    logM_sps_obs:
+        Array of observed stellar masses from SPS modelling (``log10`` scale).
+    nwalkers, nsteps:
+        MCMC configuration.
+    initial_guess:
+        Initial position of the walkers in parameter space.  Must have length 5
+        corresponding to ``(mu0, beta, sigmaDM, mu_alpha, sigma_alpha)``.
+    backend_file:
+        Path to the HDF5 file used by :class:`emcee.backends.HDFBackend` for
+        storing the chain.
+    """
+
+    ndim = 5
+    if initial_guess is None:
+        initial_guess = np.array([12.5, 2.0, 0.3, 0.1, 0.1])
+
+    backend = HDFBackend(backend_file)
+    backend.reset(nwalkers, ndim)
+
+    p0 = initial_guess + 1e-3 * np.random.randn(nwalkers, ndim)
+
+    sampler = emcee.EnsembleSampler(
+        nwalkers,
+        ndim,
+        log_posterior,
+        args=(grids, logM_sps_obs),
+        backend=backend,
+    )
+    sampler.run_mcmc(p0, nsteps, progress=True)
+    return sampler
+
+
+__all__ = ["run_mcmc"]


### PR DESCRIPTION
## Summary
- implement likelihood evaluation on pre-tabulated lensing grids and expose helper to precompute them
- provide simple MCMC runner using emcee
- streamline package initialisation to expose only core utilities

## Testing
- `python -m py_compile likelihood.py run_mcmc.py __init__.py`


------
https://chatgpt.com/codex/tasks/task_e_6890d16f17b8832d817817dd209de1c3