### PR TITLE
Add simulation entry script and fix import paths

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+import numpy as np
+
+from .mock_generator.mock_generator import run_mock_simulation
+from .likelihood import precompute_grids
+from .run_mcmc import run_mcmc
+
+def main() -> None:
+    # Generate mock data for 10 samples
+    _, mock_obs = run_mock_simulation(10)
+    logM_sps_obs = mock_obs["logM_star_sps_observed"].values
+
+    # Precompute grids on halo mass
+    logMh_grid = np.linspace(11.5, 14.0, 50)
+    grids = precompute_grids(mock_obs, logMh_grid)
+
+    # Run MCMC sampling for 500 steps
+    sampler = run_mcmc(grids, logM_sps_obs, nsteps=500, nwalkers=20)
+    chain = sampler.get_chain()
+    print("Finished MCMC. Chain shape:", chain.shape)
+
+
+if __name__ == "__main__":
+    main()

--- a/mock_generator/lens_model.py
+++ b/mock_generator/lens_model.py
@@ -1,6 +1,6 @@
 import numpy as np
-from .sl_cosmology import Dang, G, M_Sun, Mpc, c, rhoc, yr
-from .sl_profiles import deVaucouleurs as deV, nfw
+from ..sl_cosmology import Dang, G, M_Sun, Mpc, c, rhoc, yr
+from ..sl_profiles import deVaucouleurs as deV, nfw
 from scipy.interpolate import interp1d, splev, splint, splrep
 from scipy.optimize import brentq, leastsq, minimize_scalar
 from scipy.integrate import quad

--- a/mock_generator/lens_properties.py
+++ b/mock_generator/lens_properties.py
@@ -1,6 +1,6 @@
 from .lens_solver import solve_single_lens
 from .lens_model import kpc_to_arcsec, LensModel
-from .sl_cosmology import Dang
+from ..sl_cosmology import Dang
 import numpy as np
 
 # SPS PARAMETER

--- a/mock_generator/lens_solver.py
+++ b/mock_generator/lens_solver.py
@@ -1,8 +1,8 @@
 from .lens_model import LensModel
 from scipy.interpolate import splrep, splint
-from .sl_cosmology import Dang, Mpc, c, G, M_Sun, rhoc
+from ..sl_cosmology import Dang, Mpc, c, G, M_Sun, rhoc
 import numpy as np
-from .sl_profiles import nfw, deVaucouleurs as deV
+from ..sl_profiles import nfw, deVaucouleurs as deV
 from scipy.optimize import brentq
 
 


### PR DESCRIPTION
## Summary
- add `main.py` that runs a 10-sample mock inference for 500 MCMC steps
- fix package-relative imports in mock generator modules

## Testing
- `python -m sl_inference_restart.main`


------
https://chatgpt.com/codex/tasks/task_e_6890d62d8d04832db7c21557cffb1e3e