### PR TITLE
Add plotting module and integrate into main

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -6,6 +6,7 @@ Minimal package initialisation exposing the core inference utilities.
 from .run_mcmc import run_mcmc
 from .likelihood import log_prior, log_likelihood, log_posterior
 from .utils import selection_function, mag_likelihood
+from .plotting import plot_chain
 
 __all__ = [
     "run_mcmc",
@@ -14,6 +15,7 @@ __all__ = [
     "log_posterior",
     "selection_function",
     "mag_likelihood",
+    "plot_chain",
 ]
 
 __version__ = "0.1"

--- a/main.py
+++ b/main.py
@@ -5,6 +5,7 @@ import numpy as np
 from .mock_generator.mock_generator import run_mock_simulation
 from .likelihood import precompute_grids
 from .run_mcmc import run_mcmc
+from .plotting import plot_chain
 
 def main() -> None:
     # Generate mock data for 10 samples
@@ -19,6 +20,7 @@ def main() -> None:
     sampler = run_mcmc(grids, logM_sps_obs, nsteps=500, nwalkers=20)
     chain = sampler.get_chain()
     print("Finished MCMC. Chain shape:", chain.shape)
+    plot_chain(chain)
 
 
 if __name__ == "__main__":

--- a/plotting.py
+++ b/plotting.py
@@ -1,0 +1,30 @@
+"""Plotting utilities for visualising inference results."""
+
+from __future__ import annotations
+
+import numpy as np
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+
+
+def plot_chain(chain: np.ndarray, fname: str = "chain_trace.png") -> None:
+    """Save a trace plot of the first parameter of an MCMC chain.
+
+    Parameters
+    ----------
+    chain:
+        MCMC chain array with shape ``(nsteps, nwalkers, ndim)``.
+    fname:
+        Output filename for the saved figure.  Defaults to ``"chain_trace.png"``.
+    """
+    fig, ax = plt.subplots(figsize=(6, 4))
+    ax.plot(chain[:, :, 0], alpha=0.3)
+    ax.set_xlabel("Step")
+    ax.set_ylabel(r"$\mu_0$")
+    fig.tight_layout()
+    fig.savefig(fname)
+    plt.close(fig)
+
+
+__all__ = ["plot_chain"]


### PR DESCRIPTION
## Summary
- Add a simple `plot_chain` utility using matplotlib to visualize the first MCMC parameter.
- Call `plot_chain` in `main` so runs produce a trace plot.
- Export `plot_chain` from the package's top level.

## Testing
- `pytest`
- `PYTHONPATH=.. python - <<'PY' ...` (runs a short MCMC and saves a test plot)


------
https://chatgpt.com/codex/tasks/task_e_6890d88f5558832d99d9788fc6028832