### PR TITLE
Align likelihood distributions with mock generator

### DIFF
--- a/make_tabulate/make_tabulate.py
+++ b/make_tabulate/make_tabulate.py
@@ -48,6 +48,8 @@ class LensGrid:
         Selection-function values for the two images.
     p_magA, p_magB:
         Magnitude likelihoods for the two images.
+    logRe:
+        Observed effective radius used when generating the grid.
     """
 
     logMh_grid: np.ndarray
@@ -59,6 +61,7 @@ class LensGrid:
     selB: np.ndarray
     p_magA: np.ndarray
     p_magB: np.ndarray
+    logRe: float
 
 
 def tabulate_likelihood_grids(
@@ -164,6 +167,7 @@ def tabulate_likelihood_grids(
                 selB=np.array(selB_list),
                 p_magA=np.array(p_magA_list),
                 p_magB=np.array(p_magB_list),
+                logRe=logRe,
             )
         )
 


### PR DESCRIPTION
## Summary
- Include generative-model parameters in likelihood and use same Msps noise and Re size relation as mock generator
- Extend `LensGrid` to carry `logRe` so likelihood can evaluate size probabilities

## Testing
- `pytest -q`
- `python - <<'PY'
import sys, numpy as np
sys.path.append('..')
from sl_inference_restart.mock_generator.mock_generator import run_mock_simulation
from sl_inference_restart.likelihood import precompute_grids, log_likelihood
mock_lens_data, mock_observed_data = run_mock_simulation(2, process=0)
logM_sps_obs = mock_observed_data["logM_star_sps_observed"].values
logMh_grid = np.linspace(11.5, 12.0, 5)
grids = precompute_grids(mock_observed_data, logMh_grid)
theta = [12.91, 2.04, 0.37, 0.1, 0.05]
ll = log_likelihood(theta, grids, logM_sps_obs)
print("logL", ll)
PY`

------
https://chatgpt.com/codex/tasks/task_e_6891d4c6cab8832d89893f98b27169b9